### PR TITLE
Renaming and Xss

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>com.whitesource</groupId>
-    <artifactId>remediation</artifactId>
+    <artifactId>CureKit</artifactId>
     <version>1.0.0</version>
 
     <properties>

--- a/src/main/java/com/whitesource/cure/Encoder.java
+++ b/src/main/java/com/whitesource/cure/Encoder.java
@@ -45,14 +45,14 @@ public class Encoder {
    * @param contents arrays {@link Object} contains all the contents.
    * @return encoded log content.
    */
-  public static String[] forMultiLogContent(@NonNull final Object[] contents) {
+  public static String[] forLogContent(@NonNull final Object[] contents) {
 
     List<String> results = new ArrayList<>();
 
     for (Object content : contents) {
       results.add(forLogContent(content));
     }
-    return (String[]) results.toArray();
+    return results.toArray(new String[results.size()]);
   }
 
   /**
@@ -75,7 +75,7 @@ public class Encoder {
    * @param content contains the content to be sanitized.
    * @return encoded Html content.
    */
-  public static String forCrlfApache(@NonNull final String content) {
+  public static String forCrlf(@NonNull final String content) {
     return StringUtils.replaceEach(
         content.toString(),
         new String[] {"\n", "\\n", "\r", "\\r", "%0d", "%0D", "%0a", "%0A", "\025"},
@@ -88,7 +88,7 @@ public class Encoder {
    * @param content {@link Object} contains the content.
    * @return encoded JavaScript block.
    */
-  public static String forJavaScriptBlock(@NonNull final Object content) {
+  public static String forJavaScriptBlockXss(@NonNull final Object content) {
 
     return Encode.forJavaScriptBlock(formatToString(content));
   }
@@ -100,7 +100,7 @@ public class Encoder {
    * @param content {@link Object} contains the content.
    * @return encoded Html content.
    */
-  public static String forHtmlContent(@NonNull final Object content) {
+  public static String forHtmlContentXss(@NonNull final Object content) {
 
     return Encode.forHtmlContent(formatToString(content));
   }
@@ -111,7 +111,7 @@ public class Encoder {
    * @param content {@link Object} contains the content.
    * @return encoded Html Attribute.
    */
-  public static String forHtmlAttribute(@NonNull final Object content) {
+  public static String forHtmlAttributeXss(@NonNull final Object content) {
 
     return Encode.forHtmlAttribute(formatToString(content));
   }
@@ -129,7 +129,7 @@ public class Encoder {
    * @param content {@link Object} contains the content.
    * @return encoded JavaScript string.
    */
-  public static String forJavaScript(@NonNull final Object content) {
+  public static String forJavaScriptXss(@NonNull final Object content) {
 
     return Encode.forJavaScript(formatToString(content));
   }
@@ -141,7 +141,7 @@ public class Encoder {
    * @param content {@link Object} contains the content.
    * @return encoded CSS String.
    */
-  public static String forCssString(@NonNull final Object content) {
+  public static String forCssStringXss(@NonNull final Object content) {
 
     return Encode.forCssString(formatToString(content));
   }
@@ -154,7 +154,7 @@ public class Encoder {
    * @param content {@link Object} contains the content.
    * @return encoded Uri component.
    */
-  public static String forUriComponent(@NonNull final Object content) {
+  public static String forUriComponentXss(@NonNull final Object content) {
 
     return Encode.forUriComponent(formatToString(content));
   }
@@ -168,7 +168,7 @@ public class Encoder {
    * @param content {@link Object} contains the content.
    * @return encoded CSS url.
    */
-  public static String forCssUrl(@NonNull final Object content) {
+  public static String forCssUrlXss(@NonNull final Object content) {
 
     return Encode.forCssUrl(formatToString(content));
   }
@@ -186,7 +186,7 @@ public class Encoder {
    * @param content {@link Object} contains the content.
    * @return encoded Html unquoted Attribute.
    */
-  public static String forHtmlUnquotedAttribute(@NonNull final Object content) {
+  public static String forHtmlUnquotedAttributeXss(@NonNull final Object content) {
 
     return Encode.forHtmlUnquotedAttribute(formatToString(content));
   }
@@ -200,7 +200,7 @@ public class Encoder {
    * @param content {@link Object} contains the content.
    * @return encoded JavaScript attribute.
    */
-  public static String forJavaScriptAttribute(@NonNull final String content) {
+  public static String forJavaScriptAttributeXss(@NonNull final String content) {
 
     return Encode.forJavaScriptAttribute(content);
   }
@@ -228,7 +228,10 @@ public class Encoder {
   private static String formatToString(Object content) {
     if (content instanceof char[]) {
       return new String((char[]) content);
+    } else if (content instanceof String) {
+      return (String) content;
+    } else {
+      throw new RuntimeException("Unsupported content type, only String and char[] are accepted");
     }
-    return (String) content;
   }
 }

--- a/src/main/java/com/whitesource/cure/Encoder.java
+++ b/src/main/java/com/whitesource/cure/Encoder.java
@@ -1,4 +1,4 @@
-package com.whitesource.remediation;
+package com.whitesource.cure;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -45,12 +45,12 @@ public class Encoder {
    * @param contents arrays {@link Object} contains all the contents.
    * @return encoded log content.
    */
-  public static String[] multiLogContentEncoder(@NonNull final Object[] contents) {
+  public static String[] forMultiLogContent(@NonNull final Object[] contents) {
 
     List<String> results = new ArrayList<>();
 
     for (Object content : contents) {
-      results.add(logContentEncoder(content));
+      results.add(forLogContent(content));
     }
     return (String[]) results.toArray();
   }
@@ -61,7 +61,7 @@ public class Encoder {
    * @param content {@link Object} contains the content.
    * @return encoded log content.
    */
-  public static String logContentEncoder(@NonNull final Object content) {
+  public static String forLogContent(@NonNull final Object content) {
     return content
         .toString()
         .replaceAll("[\n|\r|\t]", "_")
@@ -75,7 +75,7 @@ public class Encoder {
    * @param content contains the content to be sanitized.
    * @return encoded Html content.
    */
-  public static String crlfApacheEncoder(@NonNull final String content) {
+  public static String forCrlfApache(@NonNull final String content) {
     return StringUtils.replaceEach(
         content.toString(),
         new String[] {"\n", "\\n", "\r", "\\r", "%0d", "%0D", "%0a", "%0A", "\025"},
@@ -88,9 +88,9 @@ public class Encoder {
    * @param content {@link Object} contains the content.
    * @return encoded JavaScript block.
    */
-  public static String forJavaScriptBlock(@NonNull final String content) {
+  public static String forJavaScriptBlock(@NonNull final Object content) {
 
-    return Encode.forJavaScriptBlock(content);
+    return Encode.forJavaScriptBlock(formatToString(content));
   }
 
   /**
@@ -100,9 +100,9 @@ public class Encoder {
    * @param content {@link Object} contains the content.
    * @return encoded Html content.
    */
-  public static String forHtmlContent(@NonNull final String content) {
+  public static String forHtmlContent(@NonNull final Object content) {
 
-    return Encode.forHtmlContent(content);
+    return Encode.forHtmlContent(formatToString(content));
   }
 
   /**
@@ -111,9 +111,9 @@ public class Encoder {
    * @param content {@link Object} contains the content.
    * @return encoded Html Attribute.
    */
-  public static String forHtmlAttribute(@NonNull final String content) {
+  public static String forHtmlAttribute(@NonNull final Object content) {
 
-    return Encode.forHtmlAttribute(content);
+    return Encode.forHtmlAttribute(formatToString(content));
   }
 
   /**
@@ -129,9 +129,9 @@ public class Encoder {
    * @param content {@link Object} contains the content.
    * @return encoded JavaScript string.
    */
-  public static String forJavaScript(@NonNull final String content) {
+  public static String forJavaScript(@NonNull final Object content) {
 
-    return Encode.forJavaScript(content);
+    return Encode.forJavaScript(formatToString(content));
   }
 
   /**
@@ -141,9 +141,9 @@ public class Encoder {
    * @param content {@link Object} contains the content.
    * @return encoded CSS String.
    */
-  public static String forCssString(@NonNull final String content) {
+  public static String forCssString(@NonNull final Object content) {
 
-    return Encode.forCssString(content);
+    return Encode.forCssString(formatToString(content));
   }
 
   /**
@@ -154,9 +154,9 @@ public class Encoder {
    * @param content {@link Object} contains the content.
    * @return encoded Uri component.
    */
-  public static String forUriComponent(@NonNull final String content) {
+  public static String forUriComponent(@NonNull final Object content) {
 
-    return Encode.forUriComponent(content);
+    return Encode.forUriComponent(formatToString(content));
   }
 
   /**
@@ -168,9 +168,9 @@ public class Encoder {
    * @param content {@link Object} contains the content.
    * @return encoded CSS url.
    */
-  public static String forCssUrl(@NonNull final String content) {
+  public static String forCssUrl(@NonNull final Object content) {
 
-    return Encode.forCssUrl(content);
+    return Encode.forCssUrl(formatToString(content));
   }
 
   /**
@@ -186,9 +186,9 @@ public class Encoder {
    * @param content {@link Object} contains the content.
    * @return encoded Html unquoted Attribute.
    */
-  public static String forHtmlUnquotedAttribute(@NonNull final String content) {
+  public static String forHtmlUnquotedAttribute(@NonNull final Object content) {
 
-    return Encode.forHtmlUnquotedAttribute(content);
+    return Encode.forHtmlUnquotedAttribute(formatToString(content));
   }
 
   /**
@@ -223,5 +223,12 @@ public class Encoder {
     return !((charToEncode < '0' || charToEncode > '9')
         && (charToEncode < 'A' || charToEncode > 'Z')
         && (charToEncode < 'a' || charToEncode > 'z'));
+  }
+
+  private static String formatToString(Object content) {
+    if (content instanceof char[]) {
+      return new String((char[]) content);
+    }
+    return (String) content;
   }
 }

--- a/src/main/java/com/whitesource/cure/FileUtils.java
+++ b/src/main/java/com/whitesource/cure/FileUtils.java
@@ -1,4 +1,4 @@
-package com.whitesource.remediation;
+package com.whitesource.cure;
 
 import java.io.File;
 import java.io.IOException;

--- a/src/test/java/com/whitesource/cure/EncoderTest.java
+++ b/src/test/java/com/whitesource/cure/EncoderTest.java
@@ -29,45 +29,39 @@ class EncoderTest {
   }
 
   @Test
-  void forCrlfApache_htmlContent_successfullyWithResult() {
+  void forCrlf_htmlContent_successfullyWithResult() {
     String input = "a1\rb2";
     String expected = "a1b2";
 
-    String actual = forCrlfApache(input);
+    String actual = forCrlf(input);
     Assertions.assertEquals(expected, actual);
   }
 
   @Test
-  void forCrlfApache_null_successfully() {
-    Assertions.assertThrows(NullPointerException.class, () -> forCrlfApache(null));
+  void forCrlf_null_successfully() {
+    Assertions.assertThrows(NullPointerException.class, () -> forCrlf(null));
   }
 
   @Test
   @Disabled
-  void forMultiLogContent_oneElementArray_successfullyWithResult() {
+  void forLogContent_oneElementArray_successfullyWithResult() {
 
     String[] oneElementStringArray = new String[] {"Barbi\n\r\t><"};
     String[] expectedEncodedArray = new String[] {"Barbi___&gt&lt"};
 
-    String[] actualEncodedArray = forMultiLogContent(oneElementStringArray);
+    String[] actualEncodedArray = Encoder.forLogContent(oneElementStringArray);
     Assertions.assertArrayEquals(expectedEncodedArray, actualEncodedArray);
   }
 
   @Test
   @Disabled
-  void forMultiLogContent_threeElementArray_successfullyWithResult() {
+  void forLogContent_threeElementArray_successfullyWithResult() {
 
     String[] threeElementStringArray = new String[] {"I\n\r\t", "am>", "Barbi<"};
     String[] expectedEncodedArray = new String[] {"I___", "am&gt", "Barbi&lt"};
 
-    String[] actualEncodedArray = forMultiLogContent(threeElementStringArray);
+    String[] actualEncodedArray = Encoder.forLogContent(threeElementStringArray);
     Assertions.assertArrayEquals(expectedEncodedArray, actualEncodedArray);
-  }
-
-  @Test
-  void forMultiLogContent_null_successfully() {
-
-    Assertions.assertThrows(NullPointerException.class, () -> forMultiLogContent(null));
   }
 
   @Test
@@ -87,11 +81,11 @@ class EncoderTest {
   }
 
   @Test
-  void forHtmlAttribute_successfullyWithResult_array() {
+  void forHtmlAttributeXss_successfullyWithResult_array() {
     char[] chars = {'a', 'b', 'c', 'd', 'e', '<', '>'};
     String expected = "abcde&lt;>";
 
-    String actual = forHtmlAttribute(chars);
+    String actual = forHtmlAttributeXss(chars);
     Assertions.assertEquals(expected, actual);
   }
 }

--- a/src/test/java/com/whitesource/cure/EncoderTest.java
+++ b/src/test/java/com/whitesource/cure/EncoderTest.java
@@ -1,6 +1,6 @@
-package com.whitesource.remediation;
+package com.whitesource.cure;
 
-import static com.whitesource.remediation.Encoder.*;
+import static com.whitesource.cure.Encoder.*;
 
 import org.apache.commons.lang3.SystemUtils;
 import org.junit.jupiter.api.Assertions;
@@ -29,60 +29,69 @@ class EncoderTest {
   }
 
   @Test
-  void crlfApacheEncoder_htmlContent_successfullyWithResult() {
+  void forCrlfApache_htmlContent_successfullyWithResult() {
     String input = "a1\rb2";
     String expected = "a1b2";
 
-    String actual = crlfApacheEncoder(input);
+    String actual = forCrlfApache(input);
     Assertions.assertEquals(expected, actual);
   }
 
   @Test
-  void crlfApacheEncoder_null_successfully() {
-    Assertions.assertThrows(NullPointerException.class, () -> crlfApacheEncoder(null));
+  void forCrlfApache_null_successfully() {
+    Assertions.assertThrows(NullPointerException.class, () -> forCrlfApache(null));
   }
 
   @Test
   @Disabled
-  void multiLogContentEncoder_oneElementArray_successfullyWithResult() {
+  void forMultiLogContent_oneElementArray_successfullyWithResult() {
 
     String[] oneElementStringArray = new String[] {"Barbi\n\r\t><"};
     String[] expectedEncodedArray = new String[] {"Barbi___&gt&lt"};
 
-    String[] actualEncodedArray = multiLogContentEncoder(oneElementStringArray);
+    String[] actualEncodedArray = forMultiLogContent(oneElementStringArray);
     Assertions.assertArrayEquals(expectedEncodedArray, actualEncodedArray);
   }
 
   @Test
   @Disabled
-  void multiLogContentEncoder_threeElementArray_successfullyWithResult() {
+  void forMultiLogContent_threeElementArray_successfullyWithResult() {
 
     String[] threeElementStringArray = new String[] {"I\n\r\t", "am>", "Barbi<"};
     String[] expectedEncodedArray = new String[] {"I___", "am&gt", "Barbi&lt"};
 
-    String[] actualEncodedArray = multiLogContentEncoder(threeElementStringArray);
+    String[] actualEncodedArray = forMultiLogContent(threeElementStringArray);
     Assertions.assertArrayEquals(expectedEncodedArray, actualEncodedArray);
   }
 
   @Test
-  void multiLogContentEncoder_null_successfully() {
+  void forMultiLogContent_null_successfully() {
 
-    Assertions.assertThrows(NullPointerException.class, () -> multiLogContentEncoder(null));
+    Assertions.assertThrows(NullPointerException.class, () -> forMultiLogContent(null));
   }
 
   @Test
-  void logContentEncoder_fullEncodingCapabilities_successfullyWithResult() {
+  void forLogContent_fullEncodingCapabilities_successfullyWithResult() {
 
     String barbi = "Barbi\n\r\t><";
     String expected = "Barbi___&gt&lt";
 
-    String actual = logContentEncoder(barbi);
+    String actual = forLogContent(barbi);
     Assertions.assertEquals(expected, actual);
   }
 
   @Test
-  void LogContentEncoder_null_successfully() {
+  void forLogContent_null_successfully() {
 
-    Assertions.assertThrows(NullPointerException.class, () -> logContentEncoder(null));
+    Assertions.assertThrows(NullPointerException.class, () -> forLogContent(null));
+  }
+
+  @Test
+  void forHtmlAttribute_successfullyWithResult_array() {
+    char[] chars = {'a', 'b', 'c', 'd', 'e', '<', '>'};
+    String expected = "abcde&lt;>";
+
+    String actual = forHtmlAttribute(chars);
+    Assertions.assertEquals(expected, actual);
   }
 }

--- a/src/test/java/com/whitesource/cure/FileUtilsTest.java
+++ b/src/test/java/com/whitesource/cure/FileUtilsTest.java
@@ -1,7 +1,7 @@
-package com.whitesource.remediation;
+package com.whitesource.cure;
 
-import static com.whitesource.remediation.FileUtils.isFileOutsideDir;
-import static com.whitesource.remediation.FileUtils.normalize;
+import static com.whitesource.cure.FileUtils.isFileOutsideDir;
+import static com.whitesource.cure.FileUtils.normalize;
 
 import java.io.File;
 import java.io.IOException;


### PR DESCRIPTION
Renamed the encoding methods to be consistent,
renamed the package to whitesource.cure
Xss encoders now support char arrays as well as Strings